### PR TITLE
Fix for 1.7.6

### DIFF
--- a/better_buff_management/scripts/mods/better_buff_management/hud/hud_element_buff_bar.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/hud/hud_element_buff_bar.lua
@@ -27,6 +27,11 @@ function HudElementBuffBar:event_player_buff_added(player, buff_instance)
     end
 end
 
+function HudElementBuffBar:event_player_buff_stack_added(player, buff_instance)
+    if self._filter and self._filter[buff_instance._template_name] then        
+        HudElementBuffBar.super.event_player_buff_stack_added(self, player, buff_instance)
+    end    
+end
 
 -- -------------------------------
 -- ------ Private Functions ------

--- a/better_buff_management/scripts/mods/better_buff_management/ui/window.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/ui/window.lua
@@ -92,18 +92,21 @@ function ManagementWindow:_load_buffs_data()
 
     -- Go through templates and either update icons or add new buffs with icons not in save data
     local cached_items = MASTER_ITEMS.get_cached()
-    for _, template in pairs(BUFF_TEMPLATES) do
-        local icon = get_icon(template, cached_items)
 
-        if icon then
-            if buffs_data[template.name] == nil then
-                buffs_data[template.name] = BuffData:new({
-                    name = template.name,
-                    icon = icon
-                })
-            else
-                buffs_data[template.name].icon = icon
-            end
+    for buffCategory, template in pairs(BUFF_TEMPLATES) do
+        if not (buffCategory == "PREDICTED" or buffCategory == "NON_PREDICTED") then 
+          local icon = get_icon(template, cached_items)
+
+          if icon then
+              if buffs_data[template.name] == nil then
+                  buffs_data[template.name] = BuffData:new({
+                      name = template.name,
+                      icon = icon
+                  })
+              else
+                  buffs_data[template.name].icon = icon
+              end
+          end
         end
     end
 
@@ -114,7 +117,9 @@ function ManagementWindow:_save_buffs_data()
     local save_data = {}
 
     for _, data in pairs(self._buffs_data) do
-        save_data[data.name] = data:save_data()
+        if not string.is_nil_or_whitespace(data.bar_name) then
+          save_data[data.name] = data:save_data()
+        end
     end
 
     mod:set(BUFFS_DATA_SETTING_ID, save_data)


### PR DESCRIPTION
FS added in event_player_buff_stack_added 
FS also added in PREDICTED and NON_PREDICTED to the buff definitions which exploded the save file data to include all buffs
Changed the save method to filter out the non-bar related entries