### PR TITLE
feat(2.0/hidden_buffs): add ability to hide buffs globaly

### DIFF
--- a/better_buff_management/scripts/mods/better_buff_management/better_buff_management.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/better_buff_management.lua
@@ -78,9 +78,13 @@ local function add_buff_bar_hud_definitions(definitions)
     end
 
     local bars = bars_provider:smart_load_buff_bars()
-
+    local hidden_bar = bars_provider:get_hidden_bar()
     if not table.is_nil_or_empty(bars) then
         for bar_name, bar_data in pairs(bars) do
+            if bar_name == 'Hidden' then
+                goto continue
+            end
+
             table.insert(definitions, {
                 package = 'packages/ui/hud/player_buffs/player_buffs',
                 use_retained_mode = true,
@@ -94,9 +98,12 @@ local function add_buff_bar_hud_definitions(definitions)
                 },
                 params = {
                     bar_name = bar_name,
-                    bar_data = bar_data
+                    bar_data = bar_data,
+                    hidden_buffs = hidden_bar.filter
                 }
             })
+
+            ::continue::
         end
     end
 end

--- a/better_buff_management/scripts/mods/better_buff_management/hud/hud_element_buff_bar.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/hud/hud_element_buff_bar.lua
@@ -1,6 +1,7 @@
 require('scripts/ui/hud/elements/player_buffs/hud_element_player_buffs_polling')
 
 local mod = get_mod('better_buff_management')
+
 mod:io_dofile('better_buff_management/scripts/mods/better_buff_management/utilities/table')
 mod:io_dofile('better_buff_management/scripts/mods/better_buff_management/utilities/string')
 local BuffBarDefinitions = mod:io_dofile(
@@ -12,11 +13,20 @@ local BuffBar = mod:io_dofile('better_buff_management/scripts/mods/better_buff_m
 -- -------------------------------
 -- ------- Local Functions -------
 -- -------------------------------
-local function create_filter_index(raw_filter)
+local function create_filter_index(raw_filter, hidden_buffs)
     local filter = {}
 
+    local hidden_lookup = {}
+    if hidden_buffs then
+        for _, buff_name in ipairs(hidden_buffs) do
+            hidden_lookup[buff_name] = true
+        end
+    end
+
     for _, buff_name in ipairs(raw_filter) do
-        filter[buff_name] = true
+        if not hidden_lookup[buff_name] then
+            filter[buff_name] = true
+        end
     end
 
     return filter
@@ -29,7 +39,8 @@ local HudElementBuffBar = class('HudElementBuffBar', 'HudElementPlayerBuffs')
 function HudElementBuffBar:init(parent, draw_layer, start_scale, params)
     HudElementBuffBar.super.init(self, parent, draw_layer, start_scale, BuffBarDefinitions)
     self._bar_data = params and params.bar_data or BuffBar:new()
-    self._filter = create_filter_index(self._bar_data.filter)
+    self._hidden_buffs = params and params.hidden_buffs or {}
+    self._filter = create_filter_index(self._bar_data.filter, self._hidden_buffs)
 end
 
 -- -------------------------------

--- a/better_buff_management/scripts/mods/better_buff_management/lib/buff_bars_provider.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/lib/buff_bars_provider.lua
@@ -39,6 +39,9 @@ local BUFF_BARS_SETTING_ID = 'buff_bars'
 -- --------- Constructor ---------
 -- -------------------------------
 local BuffBarsProvider = class(CLASS_NAME)
+
+BuffBarsProvider.HIDDEN_BAR_NAME = 'Hidden'
+
 function BuffBarsProvider:init(buffs_provider)
     self._buffs_provider = buffs_provider or BuffsProvider:new()
     self._bars = nil
@@ -81,7 +84,6 @@ function BuffBarsProvider:load_from_old_buff_bars()
             local bar_name = buff_data.bar_name:trim()
 
             if bars[bar_name] == nil then
-                print(('Adding [%s]'):format(bar_name))
                 bars[bar_name] = BuffBar:new({
                     filter = {},
                     direction = BuffBar.DIRECTIONS.HORIZONTAL,
@@ -128,11 +130,35 @@ function BuffBarsProvider:smart_load_buff_bars()
             self._bars = self:load_buff_bars()
         end
     end
+
+    if self._bars and self._bars[self.HIDDEN_BAR_NAME] == nil then
+        self._bars[self.HIDDEN_BAR_NAME] = BuffBar:new({
+            filter = {},
+            direction = BuffBar.DIRECTIONS.HORIZONTAL,
+            alignment = BuffBar.ALIGNMENTS.VERTICAL
+        })
+    end
     return self._bars
 end
 
 function BuffBarsProvider:save_buff_bars()
     mod:set(BUFF_BARS_SETTING_ID, self._bars)
+end
+
+function BuffBarsProvider:get_hidden_bar()
+    return self._bars[self.HIDDEN_BAR_NAME]
+end
+
+function BuffBarsProvider:get_bar_names()
+    local bar_names = table.keys(self._bars)
+
+    table.sort(bar_names, function(a, b)
+        if a == self.HIDDEN_BAR_NAME then return true end
+        if b == self.HIDDEN_BAR_NAME then return false end
+        return a < b
+    end)
+
+    return bar_names
 end
 
 return BuffBarsProvider

--- a/better_buff_management/scripts/mods/better_buff_management/lib/buffs_provider.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/lib/buffs_provider.lua
@@ -171,7 +171,14 @@ function BuffsProvider:refresh()
     self:_build(true)
 end
 
-function BuffsProvider:get_all_buffs()
+function BuffsProvider:get_all_buffs(filter)
+    if type(filter) == 'table' then
+        ---@diagnostic disable-next-line: undefined-field
+        return table.filter(self._buffs, function(buff_name)
+            return not filter:contains(buff_name)
+        end)
+    end
+
     return self._buffs
 end
 

--- a/better_buff_management/scripts/mods/better_buff_management/ui/components/buff_bars_component.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/ui/components/buff_bars_component.lua
@@ -53,10 +53,7 @@ end
 -- -------------------------------
 
 function BuffBarsComponent:_bar_names()
-    local bar_names = table.keys(self._bars)
-    table.sort(bar_names)
-
-    return bar_names
+    return self._bars_provider:get_bar_names()
 end
 
 function BuffBarsComponent:_update_buffs(window_id, bar_data)

--- a/better_buff_management/scripts/mods/better_buff_management/ui/components/search_component.lua
+++ b/better_buff_management/scripts/mods/better_buff_management/ui/components/search_component.lua
@@ -47,10 +47,7 @@ end
 -- ------ Private Functions ------
 -- -------------------------------
 function SearchComponent:_bar_names()
-    local bar_names = table.keys(self._bars)
-    table.sort(bar_names)
-
-    return bar_names
+    return self._bars_provider:get_bar_names()
 end
 
 function SearchComponent:_init_search_data()


### PR DESCRIPTION
## Description

Added a dedicated hidden buff bar that is not rendered. All buffs in this bar will be hidden from all custom buff bars.

They will not be hidden from the default bar.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Opened `Meat Grinder` added one stimm buff to the hidden bar.
Used the stimm matching the buff
It did not display on the Stimm bar

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where appropriate.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings or errors.
